### PR TITLE
introduce semaphore pipeline and update version of elixir and credo

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -35,7 +35,7 @@
         # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
         # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
         #
-        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: [:test], mass_threshold: 45},
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
@@ -46,6 +46,7 @@
         #
         ## Readability Checks
         #
+        {Credo.Check.Readability.AliasOrder, exit_status: 0},
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},

--- a/.semaphore/push.yml
+++ b/.semaphore/push.yml
@@ -1,0 +1,19 @@
+version: v1.0
+name: Push to Dockerhub
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Push
+    task:
+      jobs:
+        - name: Push to dockerhub
+          commands:
+            - checkout
+            - docker login
+            - make setup
+            - make build
+            - make push
+      secrets:
+        - name: dockerhub-robot

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,22 @@
+version: v1.0
+name: Build image
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Build image
+    task:
+      prologue:
+        commands:
+          - checkout
+      jobs:
+        - name: make build
+          commands:
+            - make setup
+            - make build
+promotions:
+  - name: Push to DockerHub
+    pipeline_file: push.yml
+    auto_promote:
+      when: branch = 'master' AND result = 'passed'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.5.1-alpine
+FROM elixir:1.13.4-alpine
 MAINTAINER Rendered Text <devs@renderedtext.com>
 
 ENV MIX_ENV test
@@ -7,7 +7,7 @@ RUN apk add --update git && mix local.hex --force
 
 RUN mix archive.install hex bunt 0.2.0 --force
 RUN mix archive.install hex poison --force
-RUN mix archive.install hex credo 0.9.2 --force
+RUN mix archive.install hex credo 1.6.5 --force
 
 RUN mkdir -p /home/credo
 ADD .credo.exs /home/credo/.credo.exs
@@ -15,4 +15,4 @@ ADD .credo.exs /home/credo/.credo.exs
 VOLUME /home/credo/code
 WORKDIR /home/credo/code
 
-CMD ["sh", "-c", "mix credo --strict"]
+ENTRYPOINT ["sh", "-c", "mix credo --strict"]

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,8 @@ push:
 	docker tag renderedtext/credo:latest renderedtext/credo:$(DOCKER_IMAGE_TAG)
 	docker push renderedtext/credo:$(DOCKER_IMAGE_TAG)
 	docker push renderedtext/credo:latest
+
+setup:
+	docker run --privileged --rm tonistiigi/binfmt --install all
+	docker buildx create --name mybuilder
+	docker buildx use mybuilder


### PR DESCRIPTION
Updates elixir to version 1.13 and credo to 1.6.5, if you need older credo and older elixir use tag:
[1d40fa5](https://hub.docker.com/layers/credo/renderedtext/credo/1d40fa5/images/sha256-255a107382511774b373d1b85d80860b7cf62482224fb6cb7e4939b03eae14ad?context=explore)